### PR TITLE
Feat: 전송 데이터를 쿼터니언에서 오일러로 앵글로 데이터 전송 수정

### DIFF
--- a/ARKitExample/ARKitExample/Network/NetworkManager.swift
+++ b/ARKitExample/ARKitExample/Network/NetworkManager.swift
@@ -28,9 +28,11 @@ class NetworkManager {
 //        let mutableData = withUnsafeMutableBytes(of: &getMotionData) { data in
 //            Data(data)
 //        }
-        
-        guard let binaryStringData = "\(motionData.position.x)/\(motionData.position.y)/\(motionData.position.x)/\(motionData.quaternion.x)/\(motionData.quaternion.y)/\(motionData.quaternion.z)/\(motionData.quaternion.w)"
+        guard let binaryStringData = "\(motionData.position.x)/\(motionData.position.y)/\(motionData.position.z)/\(motionData.rotation.x)/\(motionData.rotation.y)/\(motionData.rotation.z)/\(motionData.quaternion.w)"
             .data(using: .utf8) else { return }
+        
+//        guard let binaryStringData = "\(motionData.position.x)/\(motionData.position.y)/\(motionData.position.z)/\(motionData.quaternion.x)/\(motionData.quaternion.y)/\(motionData.quaternion.z)/\(motionData.quaternion.w)"
+//            .data(using: .utf8) else { return }
         
         // 소켓 생성
         let socket = try! Socket.create(family: .inet, type: .datagram, proto: .udp)
@@ -91,6 +93,12 @@ class NetworkManager {
         let positionY = positionBytes.advanced(by: 4).withUnsafeBytes { $0.load(as: Float.self) }
         let positionZ = positionBytes.advanced(by: 8).withUnsafeBytes { $0.load(as: Float.self) }
         
+        let rotaionBytes = data.prefix(12)
+        let rotationX = rotaionBytes.withUnsafeBytes { $0.load(as: Float.self) }
+        let rotationY = rotaionBytes.advanced(by: 4).withUnsafeBytes { $0.load(as: Float.self) }
+        let rotationZ = rotaionBytes.advanced(by: 8).withUnsafeBytes { $0.load(as: Float.self) }
+
+        
         let quaternionBytes = data.suffix(16)
         let quaternionX = quaternionBytes.withUnsafeBytes { $0.load(as: Float.self) }
         let quaternionY = quaternionBytes.advanced(by: 4).withUnsafeBytes { $0.load(as: Float.self) }
@@ -98,8 +106,10 @@ class NetworkManager {
         let quaternionW = quaternionBytes.advanced(by: 12).withUnsafeBytes { $0.load(as: Float.self) }
         
         let positionModel = Position(x: positionX, y: positionY, z: positionZ)
+        let rotationModel = Rotation(x: rotationX, y: rotationY, z: rotationZ)
         let quaternionModel = Quaternion(x: quaternionX, y: quaternionY, z: quaternionZ, w: quaternionW)
         
-        return MotionModel(position: positionModel, quaternion: quaternionModel)
+        
+        return MotionModel(position: positionModel, rotation: rotationModel ,quaternion: quaternionModel)
     }
 }

--- a/ARKitExample/ARKitExample/Sources/Model/MotionModel.swift
+++ b/ARKitExample/ARKitExample/Sources/Model/MotionModel.swift
@@ -9,7 +9,9 @@ import Foundation
 
 struct MotionModel: Codable {
     let position: Position
+    let rotation: Rotation
     let quaternion: Quaternion
+    
 }
 
 struct Position: Codable {
@@ -17,6 +19,13 @@ struct Position: Codable {
     let y: Float
     let z: Float
 }
+
+struct Rotation: Codable {
+    let x: Float
+    let y: Float
+    let z: Float
+}
+
 
 struct Quaternion: Codable {
     let x: Float

--- a/ARKitExample/ARKitExample/Sources/View/ARViewController.swift
+++ b/ARKitExample/ARKitExample/Sources/View/ARViewController.swift
@@ -65,6 +65,7 @@ class ARViewController: UIViewController {
         bind()
         setupARKit()
     }
+        
     //MARK: - Bind
     private func bind() {
         
@@ -82,7 +83,7 @@ class ARViewController: UIViewController {
             .bind { [weak self] data in
                 guard let self = self else { return }
                 self.debugLabel.text =
-                "Position \nX: \(data.position.x) / Y: \(data.position.y) / Z: \(data.position.z) \nQuaternion \nX: \(data.quaternion.x) / Y: \(data.quaternion.y) / Z: \(data.quaternion.z) / W: \(data.quaternion.w)"
+                "Position \nX: \(floor(data.position.x*100)/100) / Y: \(floor(data.position.y*100)/100) / Z: \(floor(data.position.z*100)/100) \nQuaternion \nX: \(floor(data.rotation.x*100)/100) / Y: \(floor(data.rotation.y*100)/100) / Z: \(floor(data.rotation.z*100)/100) / W: \(floor(data.quaternion.w*100)/100)"
             }
             .disposed(by: disposeBag)
     }

--- a/ARKitExample/ARKitExample/Sources/ViewModel/ARViewModel.swift
+++ b/ARKitExample/ARKitExample/Sources/ViewModel/ARViewModel.swift
@@ -10,6 +10,7 @@ import ARKit
 import RxSwift
 import RxRelay
 import RealityKit
+import simd
 
 class ARViewModel {
     //MARK: - Properties
@@ -39,7 +40,7 @@ class ARViewModel {
     private func bind() {
         motionData.subscribe { [weak self] data in
             guard let data = data.element else { return }
-            self?.network.sendBinaryData(_motionData: data)
+            self?.network.sendBinaryData(motionData: data)
         }
         .disposed(by: disposeBag)
     }
@@ -48,18 +49,28 @@ class ARViewModel {
     func processARCamera(currentFrame: ARFrame) {
         let cameraTransform = currentFrame.camera.transform
         
+        
         let rowPosition = cameraTransform.columns.3
+        let eulerAngles = currentFrame.camera.eulerAngles
         let orientation = simd_quaternion(cameraTransform)
-//        let euler = currentFrame.camera.eulerAngles
+
+        let rowRotation = simd_quatf(cameraTransform)
         
         // 가공
         let position = Position(x: rowPosition.x,
                                 y: rowPosition.y,
                                 z: rowPosition.z)
+        
+        let rotation = Rotation(x: eulerAngles.x,
+                                  y: eulerAngles.y,
+                                  z: eulerAngles.z)
+        
         let quaternion = Quaternion(x: orientation.imag.x,
                                     y: orientation.imag.y,
                                     z: orientation.imag.z,
                                     w: orientation.real)
-        motionData.accept(MotionModel(position: position, quaternion: quaternion))
+        
+
+        motionData.accept(MotionModel(position: position,rotation: rotation, quaternion: quaternion))
     }
 }


### PR DESCRIPTION
- 데이터 전송 메서드에서 기존 쿼터니언 데이터에서 오일러 앵글 데이터 전송으로 변경(쿼터니언의 마지막 변수는 데이터 넘어가는 중.)
- 'MotionModel' Rotation 구조체 추가
- ARView에서 표시되는 데이터 소수점 2번째 자리에서 버리도록 수정
- 로테이션 구조체에 카메라 기준의 오일러앵글 데이터 할당